### PR TITLE
JBTM-3257 Changed test to check ERROR is returned if outbound socket …

### DIFF
--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/recovery/RecoverySocketUnitTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/recovery/RecoverySocketUnitTest.java
@@ -146,10 +146,12 @@ public class RecoverySocketUnitTest {
     @Test
     public void socketNullWrite() throws Exception {
         try (Socket connectorSocket = getSocket()) {
+            BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), StandardCharsets.UTF_8));
             PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), StandardCharsets.UTF_8));
-            toServer.println("PING");
+            toServer.print("PING");
+            connectorSocket.shutdownOutput();
             // no flush + waiting for getting NPE
-            Thread.sleep(500);
+            assertEquals("ERROR", fromServer.readLine());
         } catch (final SocketTimeoutException stex) {
             failOnSocketTimeout(stex, RecoveryDriver.SCAN);
         }


### PR DESCRIPTION
…is closed and so the remote side should see a null

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: JBTM-XYZ Subject
- [ ] Pull Request contains link to the JIRA issue(s)

The build axis can be controlled by prefixing a ! on the following as appropriate.

MAIN TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB BLACKTIE PERF LRA NO_WIN DB_TESTS mysql db2 postgres oracle
